### PR TITLE
Made mozmaker partials options available on sidebar

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -129,6 +129,8 @@ const CONTENT_CSS = [
 	window.app.tinymceWpSkin,
 	'//s1.wp.com/wp-includes/css/dashicons.css',
 	window.app.tinymceEditorCss,
+	'//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css',
+	'//mozilla.github.io/mozmaker/dest/css/mozmaker.css',
 	'//s1.wp.com/i/fonts/merriweather/merriweather.css',
 ];
 


### PR DESCRIPTION
Fixes #41 
- [x] add `mozmaker.css` and `bootstrap.css` to TinyMCE
- [x] remove "Testimonials" and "Portfolio" from sidebar
- [x] add `mozmaker-templates` so that the partials options appear on sidebar

@alicoding or @cadecairos , r?
